### PR TITLE
chore(license): delete badge license (visible in readme.md)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,5 @@
 # LICENSE
 
-[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-
 ## Copyright (c) 2025 - Ludovic Girard
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:


### PR DESCRIPTION
Le badge est déjà visible dans le fichier README.md